### PR TITLE
giphy.go: use *Giphy.ID instead of *Giphy

### DIFF
--- a/pkg/lgtm/giphy/giphy.go
+++ b/pkg/lgtm/giphy/giphy.go
@@ -60,7 +60,7 @@ func (c *client) GetRandom() (string, error) {
 	}
 	rand.Seed(time.Now().Unix())
 	index := rand.Intn(len(giphies))
-	gifURL := fmt.Sprintf(gifURLFormat, giphies[index])
+	gifURL := fmt.Sprintf(gifURLFormat, giphies[index].ID)
 	return lgtm.MarkdownStyle(gifURL), nil
 }
 


### PR DESCRIPTION
use *Giphy.ID instead of *Giphy.
Maybe this change will fix #37 .