### PR TITLE
Include action version in minimal example

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,7 +47,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@1.0.0
-      - uses: micnncim/action-lgtm-reaction@
+      - uses: micnncim/action-lgtm-reaction@master
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 ```


### PR DESCRIPTION
Currently the minimal example doesn't work because the version of the action is not
specified, which causes the GH actions parser to fail parsing the workflow file.