### PR TITLE
Accept uppercase LGTM as one of the default triggers

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -5,7 +5,7 @@ inputs:
   trigger:
     description: 'Trigger comment on issue to send reaction'
     required: false
-    default: '["^lgtm$", "^[gG]ood [jJ]ob!?$"]'
+    default: '["(?i)^lgtm$", "^[gG]ood [jJ]ob!?$"]'
   overide:
     description: 'Whether the original comment is overridden'
     required: false


### PR DESCRIPTION
Hi! I always forget the `lgtm` in the default trigger is lowercase. I know I can override the trigger but I'm thinking maybe you'll want to accept uppercase `LGTM` as one of the default triggers? Even this repository's description uses the uppercase variant in a few cases including the README picture so I think it might make sense? WDYT?

BTW as far as I can tell this shouldn't already work because the regex case-insensitive flag in the default input string is missing and `parseTrigger` doesn't add it but if it already does work maybe the problem is just with our setup. I don't use Go so I just followed what I learnt on SO in terms of how to make a pattern case-insensitive.